### PR TITLE
Add tear-off countdown calendars

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,215 +1,32 @@
 <!DOCTYPE html>
 <html lang="ru">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Двойной таймер</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            text-align: center;
-            margin: 0;
-            padding: 20px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
-            min-height: 100vh;
-        }
-        .container {
-            max-width: 1200px;
-            margin: 0 auto;
-        }
-        h1 {
-            font-size: 2.5em;
-            margin-bottom: 10px;
-            text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-        }
-        .subtitle {
-            font-size: 1.2em;
-            margin-bottom: 40px;
-            opacity: 0.9;
-        }
-        .timer-section {
-            background: rgba(255, 255, 255, 0.1);
-            padding: 30px;
-            border-radius: 15px;
-            backdrop-filter: blur(10px);
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-            margin: 30px auto;
-            max-width: 900px;
-        }
-        .timer-title {
-            font-size: 2em;
-            margin-bottom: 20px;
-            color: #fff;
-            text-shadow: 1px 1px 2px rgba(0,0,0,0.3);
-        }
-        .timer-display {
-            font-size: 1.8em;
-            font-weight: bold;
-            margin: 20px 0;
-        }
-        .time-units {
-            display: flex;
-            justify-content: center;
-            flex-wrap: wrap;
-            gap: 15px;
-            margin: 20px 0;
-        }
-        .time-unit {
-            background: rgba(255, 255, 255, 0.2);
-            padding: 15px;
-            border-radius: 10px;
-            min-width: 100px;
-            margin: 5px;
-        }
-        .number {
-            font-size: 2.2em;
-            font-weight: bold;
-            display: block;
-        }
-        .label {
-            font-size: 0.7em;
-            opacity: 0.9;
-            text-transform: uppercase;
-            letter-spacing: 1px;
-            margin-top: 5px;
-        }
-        @media (max-width: 768px) {
-            .time-unit {
-                min-width: 70px;
-                padding: 10px;
-            }
-            .number {
-                font-size: 1.6em;
-            }
-            .timer-title {
-                font-size: 1.5em;
-            }
-            h1 {
-                font-size: 2em;
-            }
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Отрывной календарь</title>
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div class="container">
-        <h1>Двойной таймер</h1>
-        <p class="subtitle">Обратный отсчет до важных дат 2026 года</p>
-        
-        <!-- Таймер до 1 марта 2026 -->
-        <div class="timer-section">
-            <h2 class="timer-title">До 1 марта 2026 года осталось:</h2>
-            <div class="timer-display" id="timer1">
-                <div class="time-units">
-                    <div class="time-unit">
-                        <span class="number" id="months1">00</span>
-                        <span class="label">месяцев</span>
-                    </div>
-                    <div class="time-unit">
-                        <span class="number" id="days1">00</span>
-                        <span class="label">дней</span>
-                    </div>
-                    <div class="time-unit">
-                        <span class="number" id="hours1">00</span>
-                        <span class="label">часов</span>
-                    </div>
-                    <div class="time-unit">
-                        <span class="number" id="minutes1">00</span>
-                        <span class="label">минут</span>
-                    </div>
-                    <div class="time-unit">
-                        <span class="number" id="seconds1">00</span>
-                        <span class="label">секунд</span>
-                    </div>
-                </div>
-            </div>
+  <main class="wrapper">
+    <section class="calendar" id="cal1" data-target="2026-03-01T00:00:00+01:00">
+      <div class="stack">
+        <div class="page current">
+          <h2>До 1 марта 2026</h2>
+          <div class="countdown" aria-live="polite"></div>
         </div>
-        
-        <!-- Таймер до 23 апреля 2026 -->
-        <div class="timer-section">
-            <h2 class="timer-title">До 23 апреля 2026 года осталось:</h2>
-            <div class="timer-display" id="timer2">
-                <div class="time-units">
-                    <div class="time-unit">
-                        <span class="number" id="months2">00</span>
-                        <span class="label">месяцев</span>
-                    </div>
-                    <div class="time-unit">
-                        <span class="number" id="days2">00</span>
-                        <span class="label">дней</span>
-                    </div>
-                    <div class="time-unit">
-                        <span class="number" id="hours2">00</span>
-                        <span class="label">часов</span>
-                    </div>
-                    <div class="time-unit">
-                        <span class="number" id="minutes2">00</span>
-                        <span class="label">минут</span>
-                    </div>
-                    <div class="time-unit">
-                        <span class="number" id="seconds2">00</span>
-                        <span class="label">секунд</span>
-                    </div>
-                </div>
-            </div>
+      </div>
+      <button class="sound-toggle" aria-pressed="false" aria-label="звук">🔈</button>
+    </section>
+    <section class="calendar" id="cal2" data-target="2026-04-23T00:00:00+02:00">
+      <div class="stack">
+        <div class="page current">
+          <h2>До 23 апреля 2026</h2>
+          <div class="countdown" aria-live="polite"></div>
         </div>
-    </div>
-
-    <script>
-        function updateTimer(targetDate, monthsId, daysId, hoursId, minutesId, secondsId) {
-            const currentDate = new Date();
-            let diffTime = targetDate - currentDate;
-            
-            if (diffTime <= 0) {
-                document.getElementById(monthsId).textContent = '00';
-                document.getElementById(daysId).textContent = '00';
-                document.getElementById(hoursId).textContent = '00';
-                document.getElementById(minutesId).textContent = '00';
-                document.getElementById(secondsId).textContent = '00';
-                return;
-            }
-            
-            // Вычисляем месяцы
-            let months = 0;
-            let tempDate = new Date(currentDate);
-            
-            while (tempDate < targetDate) {
-                tempDate.setMonth(tempDate.getMonth() + 1);
-                if (tempDate <= targetDate) {
-                    months++;
-                } else {
-                    tempDate.setMonth(tempDate.getMonth() - 1);
-                    break;
-                }
-            }
-            
-            // Оставшееся время после вычитания месяцев
-            const remainingTime = targetDate - tempDate;
-            const diffDays = Math.floor(remainingTime / (1000 * 60 * 60 * 24));
-            const diffHours = Math.floor((remainingTime % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-            const diffMinutes = Math.floor((remainingTime % (1000 * 60 * 60)) / (1000 * 60));
-            const diffSeconds = Math.floor((remainingTime % (1000 * 60)) / 1000);
-            
-            // Обновляем элементы на странице
-            document.getElementById(monthsId).textContent = String(months).padStart(2, '0');
-            document.getElementById(daysId).textContent = String(diffDays).padStart(2, '0');
-            document.getElementById(hoursId).textContent = String(diffHours).padStart(2, '0');
-            document.getElementById(minutesId).textContent = String(diffMinutes).padStart(2, '0');
-            document.getElementById(secondsId).textContent = String(diffSeconds).padStart(2, '0');
-        }
-
-        // Целевые даты
-        const targetDate1 = new Date('2026-03-01T00:00:00');
-        const targetDate2 = new Date('2026-04-23T00:00:00');
-
-        function updateAllTimers() {
-            updateTimer(targetDate1, 'months1', 'days1', 'hours1', 'minutes1', 'seconds1');
-            updateTimer(targetDate2, 'months2', 'days2', 'hours2', 'minutes2', 'seconds2');
-        }
-
-        // Обновляем таймеры сразу и затем каждую секунду
-        updateAllTimers();
-        setInterval(updateAllTimers, 1000);
-    </script>
+      </div>
+      <button class="sound-toggle" aria-pressed="false" aria-label="звук">🔈</button>
+    </section>
+  </main>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,92 @@
+function initCountdown(calendar, targetStr) {
+  const targetDate = new Date(targetStr);
+  const countdown = calendar.querySelector('.countdown');
+  const stack = calendar.querySelector('.stack');
+  const soundBtn = calendar.querySelector('.sound-toggle');
+  const lastKey = calendar.id + '_last';
+  let sound = false;
+  let audioCtx;
+
+  function playSound() {
+    if (!sound) return;
+    if (!audioCtx) audioCtx = new (window.AudioContext||window.webkitAudioContext)();
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.frequency.value = 700;
+    gain.gain.value = 0.1;
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    osc.start();
+    osc.stop(audioCtx.currentTime + 0.15);
+  }
+
+  soundBtn.addEventListener('click', () => {
+    sound = !sound;
+    soundBtn.textContent = sound ? '🔊' : '🔈';
+    soundBtn.setAttribute('aria-pressed', sound);
+    if (audioCtx && audioCtx.state === 'suspended') audioCtx.resume();
+  });
+
+  function tearPage() {
+    const page = calendar.querySelector('.page.current');
+    const clone = page.cloneNode(true);
+    clone.classList.add('tearing');
+    stack.appendChild(clone);
+    playSound();
+    clone.addEventListener('animationend', () => clone.remove());
+  }
+
+  function checkAndTearPage() {
+    const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Berlin' });
+    const last = localStorage.getItem(lastKey);
+    if (last && last !== today) {
+      const diff = Math.max(1, Math.floor((new Date(today) - new Date(last)) / 86400000));
+      for (let i = 0; i < diff; i++) tearPage();
+    }
+    if (last !== today) localStorage.setItem(lastKey, today);
+  }
+
+  function diffTime() {
+    const now = new Date(new Date().toLocaleString('en-US', { timeZone: 'Europe/Berlin' }));
+    if (now >= targetDate) return [0,0,0,0,0];
+    let temp = new Date(now);
+    let months = (targetDate.getFullYear() - temp.getFullYear()) * 12 + targetDate.getMonth() - temp.getMonth();
+    temp.setMonth(temp.getMonth() + months);
+    if (temp > targetDate) {
+      months--;
+      temp.setMonth(temp.getMonth() - 1);
+    }
+    let remain = targetDate - temp;
+    const days = Math.floor(remain / 86400000);
+    remain -= days * 86400000;
+    const hours = Math.floor(remain / 3600000);
+    remain -= hours * 3600000;
+    const minutes = Math.floor(remain / 60000);
+    remain -= minutes * 60000;
+    const seconds = Math.floor(remain / 1000);
+    return [months, days, hours, minutes, seconds];
+  }
+
+  function render() {
+    checkAndTearPage();
+    const [mo, d, h, mi, s] = diffTime();
+    countdown.innerHTML = `<span class="num">${mo}</span> <span class="label">месяцев</span> ` +
+      `<span class="num">${d}</span> <span class="label">дней</span> ` +
+      `<span class="num">${h}</span> <span class="label">часов</span> ` +
+      `<span class="num">${mi}</span> <span class="label">минут</span> ` +
+      `<span class="num">${s}</span> <span class="label">секунд</span>`;
+    if (mo + d + h + mi + s === 0) {
+      countdown.textContent = 'Событие наступило!';
+      calendar.classList.add('finished');
+    }
+  }
+
+  render();
+  setInterval(render, 1000);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.calendar').forEach(cal => {
+    initCountdown(cal, cal.dataset.target);
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,75 @@
+body{
+  margin:0;
+  font-family:Arial,Helvetica,sans-serif;
+  background:#f3f3f3;
+  color:#333;
+  line-height:1.4;
+  padding:1rem;
+}
+.wrapper{
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:center;
+  gap:1.5rem;
+}
+.calendar{
+  width:280px;
+  position:relative;
+}
+.stack{
+  position:relative;
+  padding-top:1.5rem;
+}
+.page{
+  background:#fff;
+  border:1px solid #ccc;
+  border-radius:4px;
+  padding:1rem;
+  box-shadow:0 4px 6px rgba(0,0,0,.1);
+  text-align:center;
+  position:relative;
+}
+.stack::before,.stack::after{
+  content:"";
+  position:absolute;
+  left:0;right:0;
+  height:100%;
+  background:#fafafa;
+  border:1px solid #ddd;
+  top:.2rem;
+  z-index:-1;
+}
+.stack::after{top:.4rem;}
+.countdown{
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:center;
+  gap:.25rem .5rem;
+  font-size:1rem;
+}
+.countdown .num{
+  font-weight:700;
+  margin-right:.2rem;
+}
+.sound-toggle{
+  margin-top:.5rem;
+  background:#fff;
+  border:1px solid #ccc;
+  border-radius:4px;
+  padding:.25rem .5rem;
+  cursor:pointer;
+}
+.tearing{
+  position:absolute;
+  left:0;right:0;
+  animation:tear .6s forwards ease;
+}
+@keyframes tear{
+  0%{transform:rotate(0) translateY(0);opacity:1;}
+  100%{transform:rotate(8deg) translateY(100%);opacity:0;}
+}
+.finished .countdown{color:#d00;font-weight:700;}
+@media(max-width:600px){
+  .calendar{width:90%;}
+  .wrapper{flex-direction:column;align-items:center;}
+}


### PR DESCRIPTION
## Summary
- add two daily tear-off calendars counting down to March and April 2026
- style calendars and add optional sound
- include JS for timezone-aware counters and page-tear animation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6882999911f08328b5162b1b7f8f6c76