### PR TITLE
Remove double border effect on countdown cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -548,6 +548,7 @@
             background-color: rgb(255 255 255 / 0.04);
             border-radius: 1rem;
             padding: 0.75rem;
+            border: 1px solid rgb(255 255 255 / 0.15);
             box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04), inset 0 1px 0 rgba(255, 255, 255, 0.12);
             transform: translateY(0);
             transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
@@ -557,15 +558,6 @@
             background-color: rgb(255 255 255 / 0.08);
             box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.2);
             transform: translateY(-1px);
-        }
-
-        .glass-card-ultra-transparent .border-glass {
-            border: 1px solid rgb(255 255 255 / 0.15);
-            transition: all 0.5s;
-        }
-
-        .glass-card-ultra-transparent:hover .border-glass {
-            border: 1px solid rgb(255 255 255 / 0.25);
         }
 
         .duration-500 {
@@ -841,7 +833,6 @@
                                 <div class="group text-center">
                                     <div class="glass-card-ultra-transparent transition-all duration-500">
                                         <div class="absolute inset-0 bg-gradient-to-br from-white/6 via-white/3 to-white/2 rounded-2xl xl:rounded-3xl"></div>
-                                        <div class="absolute inset-0 rounded-2xl xl:rounded-3xl border border-white/15 border-glass"></div>
                                         <div class="relative z-10 space-y-2 xl:space-y-3">
                                             <div class="timer-number text-white/90 font-light tabular-nums drop-shadow-lg" id="months-mobile">00</div>
                                             <div class="text-xs xl:text-sm text-white/70 uppercase tracking-wide font-medium">месяцев</div>
@@ -853,7 +844,6 @@
                                 <div class="group text-center">
                                     <div class="glass-card-ultra-transparent transition-all duration-500">
                                         <div class="absolute inset-0 bg-gradient-to-br from-white/6 via-white/3 to-white/2 rounded-2xl xl:rounded-3xl"></div>
-                                        <div class="absolute inset-0 rounded-2xl xl:rounded-3xl border border-white/15 border-glass"></div>
                                         <div class="relative z-10 space-y-2 xl:space-y-3">
                                             <div class="timer-number text-white/90 font-light tabular-nums drop-shadow-lg" id="days-mobile">00</div>
                                             <div class="text-xs xl:text-sm text-white/70 uppercase tracking-wide font-medium">дней</div>
@@ -869,7 +859,6 @@
                                 <div class="group text-center">
                                     <div class="glass-card-ultra-transparent transition-all duration-500">
                                         <div class="absolute inset-0 bg-gradient-to-br from-white/6 via-white/3 to-white/2 rounded-2xl xl:rounded-3xl"></div>
-                                        <div class="absolute inset-0 rounded-2xl xl:rounded-3xl border border-white/15 border-glass"></div>
                                         <div class="relative z-10 space-y-2 xl:space-y-3">
                                             <div class="timer-number text-white/90 font-light tabular-nums drop-shadow-lg" id="hours-mobile">00</div>
                                             <div class="text-xs xl:text-sm text-white/70 uppercase tracking-wide font-medium">часов</div>
@@ -881,7 +870,6 @@
                                 <div class="group text-center">
                                     <div class="glass-card-ultra-transparent transition-all duration-500">
                                         <div class="absolute inset-0 bg-gradient-to-br from-white/6 via-white/3 to-white/2 rounded-2xl xl:rounded-3xl"></div>
-                                        <div class="absolute inset-0 rounded-2xl xl:rounded-3xl border border-white/15 border-glass"></div>
                                         <div class="relative z-10 space-y-2 xl:space-y-3">
                                             <div class="timer-number text-white/90 font-light tabular-nums drop-shadow-lg" id="minutes-mobile">00</div>
                                             <div class="text-xs xl:text-sm text-white/70 uppercase tracking-wide font-medium">минут</div>
@@ -898,7 +886,6 @@
                                     <div class="group text-center">
                                         <div class="glass-card-ultra-transparent transition-all duration-500">
                                             <div class="absolute inset-0 bg-gradient-to-br from-white/6 via-white/3 to-white/2 rounded-2xl xl:rounded-3xl"></div>
-                                            <div class="absolute inset-0 rounded-2xl xl:rounded-3xl border border-white/15 border-glass"></div>
                                             <div class="relative z-10 space-y-2 xl:space-y-3">
                                                 <div class="timer-number text-white/90 font-light tabular-nums drop-shadow-lg" id="seconds-mobile">00</div>
                                                 <div class="text-xs xl:text-sm text-white/70 uppercase tracking-wide font-medium">секунд</div>
@@ -918,7 +905,6 @@
                         <div class="group text-center">
                             <div class="glass-card-ultra-transparent transition-all duration-500">
                                 <div class="absolute inset-0 bg-gradient-to-br from-white/6 via-white/3 to-white/2 rounded-2xl xl:rounded-3xl"></div>
-                                <div class="absolute inset-0 rounded-2xl xl:rounded-3xl border border-white/15 border-glass"></div>
                                 <div class="relative z-10 space-y-2 xl:space-y-3">
                                     <div class="timer-number text-white/90 font-light tabular-nums drop-shadow-lg" id="months-desktop">00</div>
                                     <div class="text-xs xl:text-sm text-white/70 uppercase tracking-wide font-medium">месяцев</div>
@@ -931,7 +917,6 @@
                         <div class="group text-center">
                             <div class="glass-card-ultra-transparent transition-all duration-500">
                                 <div class="absolute inset-0 bg-gradient-to-br from-white/6 via-white/3 to-white/2 rounded-2xl xl:rounded-3xl"></div>
-                                <div class="absolute inset-0 rounded-2xl xl:rounded-3xl border border-white/15 border-glass"></div>
                                 <div class="relative z-10 space-y-2 xl:space-y-3">
                                     <div class="timer-number text-white/90 font-light tabular-nums drop-shadow-lg" id="days-desktop">00</div>
                                     <div class="text-xs xl:text-sm text-white/70 uppercase tracking-wide font-medium">дней</div>
@@ -944,7 +929,6 @@
                         <div class="group text-center">
                             <div class="glass-card-ultra-transparent transition-all duration-500">
                                 <div class="absolute inset-0 bg-gradient-to-br from-white/6 via-white/3 to-white/2 rounded-2xl xl:rounded-3xl"></div>
-                                <div class="absolute inset-0 rounded-2xl xl:rounded-3xl border border-white/15 border-glass"></div>
                                 <div class="relative z-10 space-y-2 xl:space-y-3">
                                     <div class="timer-number text-white/90 font-light tabular-nums drop-shadow-lg" id="hours-desktop">00</div>
                                     <div class="text-xs xl:text-sm text-white/70 uppercase tracking-wide font-medium">часов</div>
@@ -957,7 +941,6 @@
                         <div class="group text-center">
                             <div class="glass-card-ultra-transparent transition-all duration-500">
                                 <div class="absolute inset-0 bg-gradient-to-br from-white/6 via-white/3 to-white/2 rounded-2xl xl:rounded-3xl"></div>
-                                <div class="absolute inset-0 rounded-2xl xl:rounded-3xl border border-white/15 border-glass"></div>
                                 <div class="relative z-10 space-y-2 xl:space-y-3">
                                     <div class="timer-number text-white/90 font-light tabular-nums drop-shadow-lg" id="minutes-desktop">00</div>
                                     <div class="text-xs xl:text-sm text-white/70 uppercase tracking-wide font-medium">минут</div>
@@ -970,7 +953,6 @@
                         <div class="group text-center">
                             <div class="glass-card-ultra-transparent transition-all duration-500">
                                 <div class="absolute inset-0 bg-gradient-to-br from-white/6 via-white/3 to-white/2 rounded-2xl xl:rounded-3xl"></div>
-                                <div class="absolute inset-0 rounded-2xl xl:rounded-3xl border border-white/15 border-glass"></div>
                                 <div class="relative z-10 space-y-2 xl:space-y-3">
                                     <div class="timer-number text-white/90 font-light tabular-nums drop-shadow-lg" id="seconds-desktop">00</div>
                                     <div class="text-xs xl:text-sm text-white/70 uppercase tracking-wide font-medium">секунд</div>


### PR DESCRIPTION
## Summary
- add a single border on countdown cards and remove the extra overlay causing a double outline

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692818d264c8832886d664a00bec290c)